### PR TITLE
Update @schematichq/schematic-components to 0.7.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.14.0",
-    "@schematichq/schematic-components": "0.7.8",
+    "@schematichq/schematic-components": "0.7.9",
     "@schematichq/schematic-react": "^1.2.4",
     "@schematichq/schematic-typescript-node": "^1.1.10",
     "@stripe/react-stripe-js": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,10 +343,10 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.10.5.tgz#3a1c12c959010a55c17d46b395ed3047b545c246"
   integrity sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==
 
-"@schematichq/schematic-components@0.7.8":
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-0.7.8.tgz#25d008a75542543521f16760f68498adc4f2dae9"
-  integrity sha512-aX0fhMsCtJH6+cezRaYTY7W/2gHl4dXw9ZIE93AZPWfCE2dx1lQv9RcRYRLpcf7tvZbtCSjWdkyiKEomYAM3SQ==
+"@schematichq/schematic-components@0.7.9":
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-0.7.9.tgz#c5e8499699464ea5f57452cea19b855a92e9fefb"
+  integrity sha512-l8y0mtDfH5fHCCTXU4X/Dy6J7rFR7t7/W7BkJITwp8zX+C369hL4mf/SCQe6O56YHyMWnqLHgGFM3+niuTYvGQ==
   dependencies:
     "@stripe/stripe-js" "^7.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
This PR updates the @schematichq/schematic-components package to version 0.7.9.

This update was automatically created by the schematic-components deployment process.