### PR TITLE
[SCH-3588] Add `PricingTable` to Next.js example app

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { EmbedProvider, PricingTable } from "@schematichq/schematic-components";
+
+export default function Pricing() {
+  const apiKey = process.env.NEXT_PUBLIC_SCHEMATIC_PUBLISHABLE_KEY;
+  const apiUrl = process.env.NEXT_PUBLIC_SCHEMATIC_API_URL;
+  const apiConfig = apiUrl ? { basePath: apiUrl } : undefined;
+
+  return (
+    <EmbedProvider apiKey={apiKey} apiConfig={apiConfig} debug>
+      <h1 className="text-2xl font-bold mb-4">Pricing</h1>
+      <PricingTable callToActionUrl="/usage" />
+    </EmbedProvider>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,12 +7,22 @@ const Navbar = () => {
   return (
     <nav className="w-full bg-gray-800 p-4">
       <div className="max-w-7xl mx-auto flex justify-between items-center">
-        <Link
-          href="/"
-          className="text-white text-xl font-bold hover:text-gray-300"
-        >
-          Schematic
-        </Link>
+        <div className="flex items-center space-x-4">
+          <Link
+            href="/"
+            className="text-white text-xl font-bold hover:text-gray-300"
+          >
+            Schematic
+          </Link>
+        </div>
+
+        <div className="flex items-center space-x-4">
+          <div className="text-gray-500">Features</div>
+          <div className="text-gray-500">Docs</div>
+          <Link href="/pricing" className="text-white hover:text-gray-300">
+            Pricing
+          </Link>
+        </div>
 
         <div className="flex items-center space-x-4">
           <Link href="/usage" className="text-white hover:text-gray-300">


### PR DESCRIPTION
- adds the standalone pricing table to a new pricing page
- updates the navbar to include a link to this new page (as well as some placeholder nav links)