### PR TITLE
Update @schematichq/schematic-components to 2.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.1",
-    "@schematichq/schematic-components": "2.14.0",
+    "@schematichq/schematic-components": "2.14.1",
     "@schematichq/schematic-react": "1.3.1",
     "@schematichq/schematic-typescript-node": "^1.4.4",
     "@stripe/react-stripe-js": "^5.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,10 +610,10 @@
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@schematichq/schematic-components@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.14.0.tgz#68d1f867fe52e247e9aaf67449f51bc8d977d4f7"
-  integrity sha512-zep4krXBV6Xyds6N+eQJJsfhLedz1Zwwq8LiMsQqEHOgK59OMbY3QXcmloVk6V5k2xpNfp6uDdtwd2/BkSsSOQ==
+"@schematichq/schematic-components@2.14.1":
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.14.1.tgz#78eb40f3594b387b7f450f6de0b062c4e20e1916"
+  integrity sha512-WVzVIhqVEpMudketg8QSKuMU1qnJ/YIHneuy0hv7K84X2APbPUQpQplVDBQ2BzccFG+rLI9Q0POq2wElcitiww==
   dependencies:
     "@schematichq/schematic-icons" "^0.7.0"
     "@stripe/stripe-js" "^9.6.0"


### PR DESCRIPTION
This PR updates the @schematichq/schematic-components package to version 2.14.1.

This update was automatically created by the schematic-components deployment process.