### PR TITLE
Update @schematichq/schematic-components to 2.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.1",
-    "@schematichq/schematic-components": "2.14.1",
+    "@schematichq/schematic-components": "2.15.0",
     "@schematichq/schematic-react": "1.3.1",
     "@schematichq/schematic-typescript-node": "^1.4.4",
     "@stripe/react-stripe-js": "^5.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,14 +610,14 @@
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@schematichq/schematic-components@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.14.1.tgz#78eb40f3594b387b7f450f6de0b062c4e20e1916"
-  integrity sha512-WVzVIhqVEpMudketg8QSKuMU1qnJ/YIHneuy0hv7K84X2APbPUQpQplVDBQ2BzccFG+rLI9Q0POq2wElcitiww==
+"@schematichq/schematic-components@2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.15.0.tgz#a11120551c22cdd34ea6b3e49c149cf0280bc09c"
+  integrity sha512-e/djknITsSCm+xaaiOXWeM779uRBtpxtJ/tMKgvLhRR6kFNjDH74oRWPD+GqPXAwZlSXC7vJvMjOHeSlIHPlJQ==
   dependencies:
     "@schematichq/schematic-icons" "^0.7.0"
-    "@stripe/stripe-js" "^9.6.0"
-    i18next "^26.3.0"
+    "@stripe/stripe-js" "^9.7.0"
+    i18next "^26.3.1"
     lodash "^4.18.1"
     pako "^2.1.0"
     react-i18next "16.1.6"
@@ -670,10 +670,10 @@
   dependencies:
     prop-types "^15.7.2"
 
-"@stripe/stripe-js@^9.6.0":
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.6.0.tgz#ff6dc826d38e682625a58a50f6bc913d8a8070e8"
-  integrity sha512-v5MebYvJbddSRn15fknxTVwypJPzjeIXI1Q2HBxCBrQieWna8PC+RXEVUZ3F4ANAeILEj97HzFlr0r7CXvG7ZA==
+"@stripe/stripe-js@^9.7.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.8.0.tgz#df346eb64cf770128b7d7dcaa9ca24df3b7e2f49"
+  integrity sha512-DHJpol/98VKyojNSYmpkB5vOMnlf87hPe0wPxyaYTNiTMk5QjKMXDfSZLwGctYIXAgAWDFeRABc8lFAj0BELyw==
 
 "@swc/helpers@0.5.15":
   version "0.5.15"
@@ -2307,10 +2307,10 @@ html-parse-stringify@^3.0.1:
   dependencies:
     void-elements "3.1.0"
 
-i18next@^26.3.0:
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-26.3.0.tgz#057c1165589b3f312714ea2a0c3f368c2c7cd84f"
-  integrity sha512-gHSgGpUXVmuqE2El1W61DmxeyeTlFfZgdJRWMo9jScAn5pu7TuTuiccb1zh3E2J9hEBVGJ23+96x0ieBhfuIHA==
+i18next@^26.3.1:
+  version "26.3.1"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-26.3.1.tgz#94762857f5aae0c6282d87f8f0039cbbc9f7b42d"
+  integrity sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==
 
 ieee754@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
This PR updates the @schematichq/schematic-components package to version 2.15.0.

This update was automatically created by the schematic-components deployment process.