### PR TITLE
Update @schematichq/schematic-react to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.2.1",
     "@schematichq/schematic-components": "2.16.2",
-    "@schematichq/schematic-react": "1.3.1",
+    "@schematichq/schematic-react": "1.5.0",
     "@schematichq/schematic-typescript-node": "^1.4.4",
     "@stripe/react-stripe-js": "^5.6.1",
     "axios": "^1.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,20 +651,10 @@
   dependencies:
     styled-components "^6.3.12"
 
-"@schematichq/schematic-js@^1.3.1":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@schematichq/schematic-js/-/schematic-js-1.4.0.tgz#1cdb53f0c2053f97934d65c83a95af78754dcc89"
-  integrity sha512-/fb8BXbBXFS09y6xul8JqloQWijvbE3xIOrOed1wzuaftuFWLJ8wUEGvuBRE7/3op0GhcvyT8nLdJ1y+yipaAg==
-  dependencies:
-    cross-fetch "^4.1.0"
-    uuid "^13.0.0"
-
-"@schematichq/schematic-react@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@schematichq/schematic-react/-/schematic-react-1.3.1.tgz#7baebfefe081df75f9e279ce2de22626ef4460f2"
-  integrity sha512-wDfL2ECOMHsMaAWWtzaAHH1WPOTKcTnswDJhO10kd3t7YAbe0LoJecWYMS2P1fPgFOvP3sXloYYhDLYcsWvMtQ==
-  dependencies:
-    "@schematichq/schematic-js" "^1.3.1"
+"@schematichq/schematic-react@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@schematichq/schematic-react/-/schematic-react-1.5.0.tgz#1f7aacdfe38087771aee0afddf50b0dca29edce0"
+  integrity sha512-8Y9hQ75/XXj2fwuk4dfLsGki37o5/Cnc4C9/XdTrKHAqKq1Lvc1gX74IIqPPxOH6GLEmmA9rxOvPRFgyy5YywQ==
 
 "@schematichq/schematic-typescript-node@^1.4.4":
   version "1.4.6"
@@ -1333,13 +1323,6 @@ cookie@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
   integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
-
-cross-fetch@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.1.0.tgz#8f69355007ee182e47fa692ecbaa37a52e43c3d2"
-  integrity sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==
-  dependencies:
-    node-fetch "^2.7.0"
 
 cross-spawn@^7.0.6:
   version "7.0.6"
@@ -3700,11 +3683,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-uuid@^13.0.0:
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.2.tgz#41bc9c07b12f665089c205f6507976adbdf84ff8"
-  integrity sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==
 
 uuid@^14.0.0:
   version "14.0.0"


### PR DESCRIPTION
This PR updates the @schematichq/schematic-react package to version 1.5.0.

This update was automatically created by the schematic-react deployment process.