### PR TITLE
add demo mode that runs without Clerk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# Clerk (NOT needed in demo mode — leave empty when NEXT_PUBLIC_DEMO_MODE=true)
 CLERK_SECRET_KEY=""
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=""
 NEXT_PUBLIC_SCHEMATIC_COMPONENT_ID=""
@@ -8,3 +9,13 @@ SCHEMATIC_SECRET_KEY=""
 # NEXT_PUBLIC_SCHEMATIC_API_URL="http://localhost:8080"
 # NEXT_PUBLIC_SCHEMATIC_EVENT_URL="http://localhost:8081"
 # NEXT_PUBLIC_SCHEMATIC_WEBSOCKET_URL="ws://localhost:8080"
+
+# Demo mode (no Clerk needed) — provisioned via Stripe Projects.
+# When "true", the app identifies as a single hardcoded company/user
+# (company key id="demo-co") and skips Clerk entirely. Seed entitlements
+# for the "demo-co" company in the provisioned Schematic environment.
+NEXT_PUBLIC_DEMO_MODE="true"
+NEXT_PUBLIC_DEMO_USER_KEY="demo-user"
+NEXT_PUBLIC_SCHEMATIC_API_URL="http://localhost:8080"
+# NEXT_PUBLIC_SCHEMATIC_EVENT_URL / WEBSOCKET_URL if needed for local
+# SCHEMATIC_SECRET_KEY + NEXT_PUBLIC_SCHEMATIC_PUBLISHABLE_KEY come from the provisioned environment

--- a/src/app/api/accessToken/route.ts
+++ b/src/app/api/accessToken/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { SchematicClient } from "@schematichq/schematic-typescript-node";
 
 import { getAuthOrgId, AuthError } from "../../../utils/auth";
+import { demoCompanyKeys, isDemoMode } from "../../../utils/demoContext";
 
 export async function GET() {
   const apiKey = process.env.SCHEMATIC_SECRET_KEY;
@@ -10,14 +11,16 @@ export async function GET() {
   }
 
   try {
-    const { orgId } = await getAuthOrgId();
     const basePath = process.env.NEXT_PUBLIC_SCHEMATIC_API_URL;
     const schematicClient = new SchematicClient({ apiKey, basePath });
 
+    // In demo mode there's no Clerk session — look up the hardcoded company.
+    const lookup = isDemoMode()
+      ? demoCompanyKeys
+      : { clerkId: (await getAuthOrgId()).orgId };
+
     const resp = await schematicClient.accesstokens.issueTemporaryAccessToken({
-      lookup: {
-        clerkId: orgId,
-      },
+      lookup,
     });
 
     const accessToken = resp.data.token;

--- a/src/app/api/pins/route.ts
+++ b/src/app/api/pins/route.ts
@@ -3,6 +3,7 @@ import { SchematicClient } from "@schematichq/schematic-typescript-node";
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthOrgId, AuthError } from "../../../utils/auth";
+import { demoCompanyKeys, isDemoMode } from "../../../utils/demoContext";
 
 export async function POST(request: NextRequest) {
   const apiKey = process.env.SCHEMATIC_SECRET_KEY;
@@ -14,9 +15,21 @@ export async function POST(request: NextRequest) {
   const numLocations = locations?.length ?? 0;
 
   try {
-    const { orgId } = await getAuthOrgId();
     const basePath = process.env.NEXT_PUBLIC_SCHEMATIC_API_URL;
     const schematicClient = new SchematicClient({ apiKey, basePath });
+
+    if (isDemoMode()) {
+      // No Clerk org to persist metadata to; just update the Schematic
+      // company trait so entitlement gating reflects pin count.
+      await schematicClient.companies.upsertCompany({
+        keys: demoCompanyKeys,
+        traits: { numLocations },
+      });
+
+      return NextResponse.json({ numLocations });
+    }
+
+    const { orgId } = await getAuthOrgId();
 
     await schematicClient.companies.upsertCompany({
       keys: { clerkId: orgId },

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,7 +1,12 @@
 import { SignIn } from "@clerk/nextjs";
 
-const SignInPage = () => (
-  <SignIn path="/sign-in" routing="path" signUpUrl="/sign-up" />
-);
+import { isDemoMode } from "../../utils/demoContext";
+
+const SignInPage = () =>
+  isDemoMode() ? (
+    <div>Sign-in is disabled in demo mode.</div>
+  ) : (
+    <SignIn path="/sign-in" routing="path" signUpUrl="/sign-up" />
+  );
 
 export default SignInPage;

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,7 +1,12 @@
 import { SignUp } from "@clerk/nextjs";
 
-const SignUpPage = () => (
-  <SignUp path="/sign-up" routing="path" signInUrl="/sign-in" />
-);
+import { isDemoMode } from "../../utils/demoContext";
+
+const SignUpPage = () =>
+  isDemoMode() ? (
+    <div>Sign-up is disabled in demo mode.</div>
+  ) : (
+    <SignUp path="/sign-up" routing="path" signInUrl="/sign-in" />
+  );
 
 export default SignUpPage;

--- a/src/components/ClientWrapper.tsx
+++ b/src/components/ClientWrapper.tsx
@@ -8,8 +8,10 @@ import {
 } from "@schematichq/schematic-react";
 
 import useAuthContext from "../hooks/useAuthContext";
+import { demoIdentity, isDemoMode } from "../utils/demoContext";
 import Loader from "./Loader";
 
+// Clerk-derived identify (default, non-demo behavior).
 const SchematicWrapped: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
@@ -34,6 +36,28 @@ const SchematicWrapped: React.FC<{ children: React.ReactNode }> = ({
   return children;
 };
 
+// Demo-mode identify — hardcoded company/user, no Clerk.
+const SchematicWrappedDemo: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { identify } = useSchematicEvents();
+
+  useEffect(() => {
+    void identify({
+      company: {
+        keys: demoIdentity.company.keys,
+        name: demoIdentity.company.name,
+        traits: { ...demoIdentity.company.traits },
+      },
+      keys: demoIdentity.user.keys,
+      name: demoIdentity.user.name,
+      traits: { ...demoIdentity.user.traits },
+    });
+  }, [identify]);
+
+  return children;
+};
+
 export default function ClientWrapper({
   children,
 }: {
@@ -52,20 +76,27 @@ export default function ClientWrapper({
     setIsClientSide(true);
   }, []);
 
-  return (
-    <ClerkProvider>
-      {isClientSide ? (
-        <SchematicProvider
-          publishableKey={schematicPubKey}
-          apiUrl={process.env.NEXT_PUBLIC_SCHEMATIC_API_URL}
-          eventUrl={process.env.NEXT_PUBLIC_SCHEMATIC_EVENT_URL}
-          webSocketUrl={process.env.NEXT_PUBLIC_SCHEMATIC_WEBSOCKET_URL}
-        >
-          <SchematicWrapped>{children}</SchematicWrapped>
-        </SchematicProvider>
+  const provider = (
+    <SchematicProvider
+      publishableKey={schematicPubKey}
+      apiUrl={process.env.NEXT_PUBLIC_SCHEMATIC_API_URL}
+      eventUrl={process.env.NEXT_PUBLIC_SCHEMATIC_EVENT_URL}
+      webSocketUrl={process.env.NEXT_PUBLIC_SCHEMATIC_WEBSOCKET_URL}
+    >
+      {isDemoMode() ? (
+        <SchematicWrappedDemo>{children}</SchematicWrappedDemo>
       ) : (
-        <Loader />
+        <SchematicWrapped>{children}</SchematicWrapped>
       )}
-    </ClerkProvider>
+    </SchematicProvider>
+  );
+
+  // Demo mode: skip ClerkProvider entirely so the app boots with no Clerk keys.
+  if (isDemoMode()) {
+    return isClientSide ? provider : <Loader />;
+  }
+
+  return (
+    <ClerkProvider>{isClientSide ? provider : <Loader />}</ClerkProvider>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { Show, UserButton } from "@clerk/nextjs";
 
+import { isDemoMode } from "../utils/demoContext";
+
 const Navbar = () => {
   return (
     <nav className="w-full bg-gray-800 p-4">
@@ -33,9 +35,15 @@ const Navbar = () => {
           <Link href="/usage" className="text-white hover:text-gray-300">
             Usage
           </Link>
-          <Show when="signed-in">
-            <UserButton />
-          </Show>
+          {/* Clerk's UserButton requires ClerkProvider, which is absent in
+              demo mode. Render a static label instead. */}
+          {isDemoMode() ? (
+            <span className="text-white text-sm">Demo</span>
+          ) : (
+            <Show when="signed-in">
+              <UserButton />
+            </Show>
+          )}
         </div>
       </div>
     </nav>

--- a/src/components/Weather.tsx
+++ b/src/components/Weather.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useCallback, useState, useMemo, useRef } from "react";
 import axios from "axios";
 import debounce from "lodash/debounce";
-import { useOrganization } from "@clerk/nextjs";
 import {
   useSchematicEvents,
   useSchematicFlag,
@@ -12,6 +11,7 @@ import {
   UsagePeriod,
 } from "@schematichq/schematic-react";
 
+import useSavedLocations from "../hooks/useSavedLocations";
 import Loader from "./Loader";
 
 interface WeatherData {
@@ -71,7 +71,7 @@ const Weather: React.FC = () => {
   } = useSchematicEntitlement("weather-search");
   const windSpeedFlag = useSchematicFlag("wind-speed");
   const addPinnedLocationFlag = useSchematicFlag("pinned-locations");
-  const { organization } = useOrganization();
+  const savedLocations = useSavedLocations();
 
   const updatePinnedLocations = useCallback(
     (locations: string[]) => {
@@ -93,13 +93,11 @@ const Weather: React.FC = () => {
   );
 
   useEffect(() => {
-    if (organization) {
-      const savedLocations = (organization.publicMetadata.locations ??
-        []) as string[];
+    if (savedLocations.length > 0) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       updatePinnedLocations(savedLocations);
     }
-  }, [organization, updatePinnedLocations]);
+  }, [savedLocations, updatePinnedLocations]);
 
   const fetchWeather = useCallback(
     async (location: string) => {

--- a/src/hooks/useSavedLocations.ts
+++ b/src/hooks/useSavedLocations.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useOrganization } from "@clerk/nextjs";
+
+import { isDemoMode } from "../utils/demoContext";
+
+// Returns the company's persisted pinned locations.
+//
+// In Clerk mode these live in the org's publicMetadata (written by /api/pins).
+// In demo mode there's no Clerk org, so pinned locations are session-only
+// (start empty). The selected implementation is fixed for the lifetime of the
+// process by NEXT_PUBLIC_DEMO_MODE, so exactly one hook runs on every render —
+// no Rules-of-Hooks violation.
+
+const useClerkSavedLocations = (): string[] => {
+  const { organization } = useOrganization();
+  if (!organization) return [];
+  return (organization.publicMetadata.locations ?? []) as string[];
+};
+
+const useDemoSavedLocations = (): string[] => [];
+
+const useSavedLocations: () => string[] = isDemoMode()
+  ? useDemoSavedLocations
+  : useClerkSavedLocations;
+
+export default useSavedLocations;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,10 +1,17 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isUnprotectedRoute = createRouteMatcher(["/sign-in", "/sign-up"]);
 
-export default clerkMiddleware(async (auth, req) => {
-  if (!isUnprotectedRoute(req)) await auth.protect();
-});
+const isDemoMode = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
+
+// In demo mode there is no Clerk auth — let every request through untouched
+// so the app boots with no Clerk keys configured.
+export default isDemoMode
+  ? () => NextResponse.next()
+  : clerkMiddleware(async (auth, req) => {
+      if (!isUnprotectedRoute(req)) await auth.protect();
+    });
 
 export const config = {
   matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],

--- a/src/utils/demoContext.ts
+++ b/src/utils/demoContext.ts
@@ -1,0 +1,35 @@
+// Hardcoded demo identity — no auth required.
+//
+// When NEXT_PUBLIC_DEMO_MODE === "true" the app skips Clerk entirely and
+// identifies as a single fixed company/user against a (typically local)
+// Schematic API. The demo environment must seed entitlements for the
+// company key below (`id: "demo-co"`).
+//
+// Mirrors the dashai demo pattern (lib/server-identity.ts + data/demoIdentity.ts),
+// but uses simple stable `id` keys since this app isn't bound to Metronome.
+
+export const isDemoMode = (): boolean =>
+  process.env.NEXT_PUBLIC_DEMO_MODE === "true";
+
+// Company the demo identifies as. Seed entitlements for this key in the
+// provisioned Schematic environment.
+export const demoCompanyKeys: Record<string, string> = { id: "demo-co" };
+
+// User the demo identifies as. Overridable via env so the same image can be
+// retargeted without code changes.
+export const demoUserKeys: Record<string, string> = {
+  id: process.env.NEXT_PUBLIC_DEMO_USER_KEY ?? "demo-user",
+};
+
+export const demoIdentity = {
+  company: {
+    keys: demoCompanyKeys,
+    name: process.env.NEXT_PUBLIC_DEMO_COMPANY_NAME ?? "Demo Company",
+    traits: { status: "active" } as Record<string, string | number | boolean>,
+  },
+  user: {
+    keys: demoUserKeys,
+    name: process.env.NEXT_PUBLIC_DEMO_USER_NAME ?? "Demo User",
+    traits: { status: "active" } as Record<string, string | number | boolean>,
+  },
+};


### PR DESCRIPTION
Adds a `NEXT_PUBLIC_DEMO_MODE` toggle that runs the example app without Clerk: it identifies as a single hardcoded company/user and skips `ClerkProvider` entirely. All new behavior is gated behind the flag — the default (Clerk) path is unchanged when it's unset.

Enables running schematic-next-example in the exe.dev dev sandbox (and other no-auth demos) without Clerk keys. Rebased onto current main; typecheck + lint clean.