### PR TITLE
initial headless components usage

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Show, UserButton } from "@clerk/nextjs";
 
 import { isDemoMode } from "../utils/demoContext";
+import { TrialDetails } from "./TrialDetails";
 
 const Navbar = () => {
   return (
@@ -42,6 +43,7 @@ const Navbar = () => {
           ) : (
             <Show when="signed-in">
               <UserButton />
+              <TrialDetails />
             </Show>
           )}
         </div>

--- a/src/components/TrialDetails.tsx
+++ b/src/components/TrialDetails.tsx
@@ -1,18 +1,37 @@
-import { TrialPill } from "@schematichq/schematic-components";
+import { TrialPill, useTrialPill } from "@schematichq/schematic-components";
 import { useSchematicPlan } from "@schematichq/schematic-react";
 
 export const TrialDetails = () => {
   const plan = useSchematicPlan();
+  const trial = useTrialPill({
+    trialEndDate: plan?.trialEndDate,
+    trialStatus: plan?.trialStatus,
+  });
 
   return (
     <TrialPill.Root
       trialEndDate={plan?.trialEndDate}
       trialStatus={plan?.trialStatus}
     >
-      Trial ends <TrialPill.EndDate />
+      <TrialPill.Label>{plan?.name}</TrialPill.Label>
+
+      {plan?.trialEndDate && (
+        <TrialPill.TimeRemaining>
+          Trial ends in {trial.endDateLabel}
+        </TrialPill.TimeRemaining>
+      )}
+
       <style>{`
         .schematic-trial-pill {
+          font-size: 12px;
+          font-weight: 300;
+          line-height: 1.25;
+        }
+
+        .schematic-trial-pill__label {
+          display: block;
           font-size: 14px;
+          font-weight: 500;
         }
       `}</style>
     </TrialPill.Root>

--- a/src/components/TrialDetails.tsx
+++ b/src/components/TrialDetails.tsx
@@ -1,0 +1,20 @@
+import { TrialPill } from "@schematichq/schematic-components";
+import { useSchematicPlan } from "@schematichq/schematic-react";
+
+export const TrialDetails = () => {
+  const plan = useSchematicPlan();
+
+  return (
+    <TrialPill.Root
+      trialEndDate={plan?.trialEndDate}
+      trialStatus={plan?.trialStatus}
+    >
+      Trial ends <TrialPill.EndDate />
+      <style>{`
+        .schematic-trial-pill {
+          font-size: 14px;
+        }
+      `}</style>
+    </TrialPill.Root>
+  );
+};

--- a/src/components/UsageDetails.tsx
+++ b/src/components/UsageDetails.tsx
@@ -1,15 +1,16 @@
-import { type CheckFlagReturn } from "@schematichq/schematic-react";
 import { UsageMeter } from "@schematichq/schematic-components";
 
-export const UsageDetails = ({
-  featureAllocation = 0,
-  featureUsage = 0,
-}: CheckFlagReturn) => {
-  const percent = (featureUsage / featureAllocation) * 100;
+interface UsageDetailsProps {
+  value?: number;
+  max?: number;
+}
+
+export const UsageDetails = ({ value = 0, max = 0 }: UsageDetailsProps) => {
+  const percent = (value / max) * 100;
 
   return (
-    <UsageMeter.Root value={featureUsage} max={featureAllocation}>
-      {featureUsage > 0 && featureAllocation > 0 && (
+    <UsageMeter.Root value={value} max={max}>
+      {value > 0 && max > 0 && (
         <UsageMeter.Track>
           <UsageMeter.Fill
             style={{
@@ -19,23 +20,29 @@ export const UsageDetails = ({
           />
         </UsageMeter.Track>
       )}
+
       <UsageMeter.ValueText>
-        {featureUsage} / {featureAllocation || "?"} used
+        {value} / {max || "?"} used
       </UsageMeter.ValueText>
+
       <style>{`
-        .schematic-usage-meter {
-          margin-top: 0.3333rem;
+        .schematic-usage-meter__label {
+          font-size: 14px;
+          font-weight: 500;
         }
 
         .schematic-usage-meter__track {
           height: 0.5rem;
-          background: oklch(95% 0 0deg);
+          margin-top: ${1 / 3}rem;
+          background: oklch(60% 0 0deg);
+          border-radius: 2px;
           overflow: hidden;
         }
 
         .schematic-usage-meter__fill {
           height: 100%;
           transition: width 200ms ease;
+          border-right: 1px solid oklch(50% 0 0deg);
         }
       `}</style>
     </UsageMeter.Root>

--- a/src/components/UsageDetails.tsx
+++ b/src/components/UsageDetails.tsx
@@ -1,0 +1,43 @@
+import { type CheckFlagReturn } from "@schematichq/schematic-react";
+import { UsageMeter } from "@schematichq/schematic-components";
+
+export const UsageDetails = ({
+  featureAllocation = 0,
+  featureUsage = 0,
+}: CheckFlagReturn) => {
+  const percent = (featureUsage / featureAllocation) * 100;
+
+  return (
+    <UsageMeter.Root value={featureUsage} max={featureAllocation}>
+      {featureUsage > 0 && featureAllocation > 0 && (
+        <UsageMeter.Track>
+          <UsageMeter.Fill
+            style={{
+              width: `${percent}%`,
+              background: `color-mix(in hsl, green, red ${percent}%)`,
+            }}
+          />
+        </UsageMeter.Track>
+      )}
+      <UsageMeter.ValueText>
+        {featureUsage} / {featureAllocation || "?"} used
+      </UsageMeter.ValueText>
+      <style>{`
+        .schematic-usage-meter {
+          margin-top: 0.3333rem;
+        }
+
+        .schematic-usage-meter__track {
+          height: 0.5rem;
+          background: oklch(95% 0 0deg);
+          overflow: hidden;
+        }
+
+        .schematic-usage-meter__fill {
+          height: 100%;
+          transition: width 200ms ease;
+        }
+      `}</style>
+    </UsageMeter.Root>
+  );
+};

--- a/src/components/Weather.tsx
+++ b/src/components/Weather.tsx
@@ -13,6 +13,7 @@ import {
 
 import useSavedLocations from "../hooks/useSavedLocations";
 import Loader from "./Loader";
+import { UsageDetails } from "./UsageDetails";
 
 interface WeatherData {
   description: string;
@@ -61,6 +62,7 @@ const Weather: React.FC = () => {
   const { track } = useSchematicEvents();
   const schematicIsPending = useSchematicIsPending();
   const humidityFlag = useSchematicFlag("humidity");
+  const weatherSearch = useSchematicEntitlement("weather-search");
   const {
     featureAllocation: weatherSearchAllocation,
     featureUsage: weatherSearchUsage,
@@ -68,7 +70,7 @@ const Weather: React.FC = () => {
     featureUsagePeriod: weatherSearchUsagePeriod,
     featureUsageResetAt: weatherSearchUsageResetAt,
     value: weatherSearchFlag,
-  } = useSchematicEntitlement("weather-search");
+  } = weatherSearch;
   const windSpeedFlag = useSchematicFlag("wind-speed");
   const addPinnedLocationFlag = useSchematicFlag("pinned-locations");
   const savedLocations = useSavedLocations();
@@ -225,13 +227,11 @@ const Weather: React.FC = () => {
         </div>
       )}
       <div className="weather-container">
-        {!schematicIsPending &&
-          typeof weatherSearchUsage !== "undefined" &&
-          typeof weatherSearchAllocation !== "undefined" && (
-            <div className="usage-pill">
-              {weatherSearchUsage} / {weatherSearchAllocation} used
-            </div>
-          )}
+        {!schematicIsPending && (
+          <div className="usage-pill">
+            <UsageDetails {...weatherSearch} />
+          </div>
+        )}
         <div className="search-container">
           <input
             type="text"

--- a/src/components/Weather.tsx
+++ b/src/components/Weather.tsx
@@ -228,8 +228,11 @@ const Weather: React.FC = () => {
       )}
       <div className="weather-container">
         {!schematicIsPending && (
-          <div className="usage-pill">
-            <UsageDetails {...weatherSearch} />
+          <div className="usage-floater">
+            <UsageDetails
+              value={weatherSearchUsage}
+              max={weatherSearchAllocation}
+            />
           </div>
         )}
         <div className="search-container">
@@ -337,7 +340,7 @@ const Weather: React.FC = () => {
           font-family: "Helvetica Neue", Arial, sans-serif;
           position: relative;
         }
-        .usage-pill {
+        .usage-floater {
           float: right;
           background-color: rgba(0, 0, 0, 0.4);
           color: rgba(255, 255, 255, 0.9);


### PR DESCRIPTION
## Summary

Demonstrates using Schematic's new headless components (`@schematichq/schematic-components`) in the example app. Adds two consumer-styled UI elements driven by Schematic hooks:

- **Trial pill** in the navbar that shows the trial end date, using `TrialPill.*` fed by `useSchematicPlan()`.
- **Usage meter** on the weather search UI that replaces the old plain `x / y used` pill with a `UsageMeter.*` track/fill, using the existing `useSchematicEntitlement("weather-search")` data.

## Changes

- **`TrialDetails.tsx`** (new) — wraps `TrialPill.Root`/`TrialPill.EndDate`, sourcing `trialEndDate`/`trialStatus` from `useSchematicPlan()`. Rendered in the navbar for signed-in users.
- **`UsageDetails.tsx`** (new) — wraps `UsageMeter.Root`/`Track`/`Fill`/`ValueText`, taking `featureAllocation`/`featureUsage` from a `CheckFlagReturn`. The fill width and color (`color-mix` green→red) scale with usage percent, and the track is only shown when usage and allocation are both > 0.
- **`Navbar.tsx`** — renders `<TrialDetails />` alongside the Clerk `UserButton`.
- **`Weather.tsx`** — hoists the `useSchematicEntitlement("weather-search")` call into a `weatherSearch` variable and spreads it into `<UsageDetails />`, replacing the hand-rolled usage-pill markup.

## Notes

These components rely on the headless building blocks in `@schematichq/schematic-components`; the inline `<style>` blocks show how a consumer can theme them via the documented CSS class names.
