### PR TITLE
Update @schematichq/schematic-components to 2.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.1",
-    "@schematichq/schematic-components": "2.18.0",
+    "@schematichq/schematic-components": "2.19.0",
     "@schematichq/schematic-react": "1.5.0",
     "@schematichq/schematic-typescript-node": "^1.4.4",
     "@stripe/react-stripe-js": "^5.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,16 +630,16 @@
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@schematichq/schematic-components@2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.18.0.tgz#d7f9a77d8ac403d7290c0e513b46f761f686d265"
-  integrity sha512-5LRy/scwWOrM+NCpgWMxLYujK0+EmaGlH1WkuJg6u+2KC0oaeOTO5uBNS6TON5MdHYPv7vSyhL2Ldk76y9fJSQ==
+"@schematichq/schematic-components@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.19.0.tgz#cee1543bebf4202ce898828dbee83251b5568b9d"
+  integrity sha512-s9BWdx7uU8GOCX5O4GpkoN7/oP3nQ9JKzaVrCWkCvmBzDAcusTTPhzTk89Gx7A+1X6jv/ktKYKiFzByvi154NQ==
   dependencies:
     "@schematichq/schematic-icons" "^0.8.0"
     "@stripe/stripe-js" "^9.9.0"
     i18next "^26.3.4"
     lodash "^4.18.1"
-    pako "^3.0.0"
+    pako "^3.0.1"
     react-i18next "16.1.6"
     styled-components "^6.4.3"
     uuid "^14.0.1"
@@ -3025,10 +3025,10 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-pako@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-3.0.0.tgz#53aafbe4bc0882eb302e080a3804a70c1ec02e52"
-  integrity sha512-TGPtlCI1pSUSbkOIxOUUHNrBa0muz4mAp32cYUF3RoSa5c73jiQTKOKo22gaa4DxLggQrda/DAdax5QkcHPvYA==
+pako@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-3.0.1.tgz#3156f8fa86e3cc2ae5a36369475b14d4f05696ce"
+  integrity sha512-GupotUUI0mlhugKjUs4bjOwLt3nrehy9Ys2dxC0GtgVef5cnKggkDMmf2bq2poCCuVXopWPmqsc9VDT2iJUy+w==
 
 path-exists@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR updates the @schematichq/schematic-components package to version 2.19.0.

This update was automatically created by the schematic-components deployment process.