### PR TITLE
Update @schematichq/schematic-components to 2.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.1",
-    "@schematichq/schematic-components": "2.19.0",
+    "@schematichq/schematic-components": "2.21.0",
     "@schematichq/schematic-react": "1.5.0",
     "@schematichq/schematic-typescript-node": "^1.4.4",
     "@stripe/react-stripe-js": "^5.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,18 +630,18 @@
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@schematichq/schematic-components@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.19.0.tgz#cee1543bebf4202ce898828dbee83251b5568b9d"
-  integrity sha512-s9BWdx7uU8GOCX5O4GpkoN7/oP3nQ9JKzaVrCWkCvmBzDAcusTTPhzTk89Gx7A+1X6jv/ktKYKiFzByvi154NQ==
+"@schematichq/schematic-components@2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.21.0.tgz#5bc2df6e3490a1df3acb54b708838b7bdd2874b0"
+  integrity sha512-RF4DOCT3igq6KK7eMZaXUcwkrAHi6HBAz7HT01BKWJ6oL6z2nB47vMGAbCbStEuZ32DGVwZucmP7sT8sEHqPSA==
   dependencies:
     "@schematichq/schematic-icons" "^0.8.0"
-    "@stripe/stripe-js" "^9.9.0"
-    i18next "^26.3.4"
+    "@stripe/stripe-js" "^9.12.0"
+    i18next "^26.3.6"
     lodash "^4.18.1"
     pako "^3.0.1"
     react-i18next "16.1.6"
-    styled-components "^6.4.3"
+    styled-components "^6.4.4"
     uuid "^14.0.1"
 
 "@schematichq/schematic-icons@^0.8.0":
@@ -680,10 +680,10 @@
   dependencies:
     prop-types "^15.7.2"
 
-"@stripe/stripe-js@^9.9.0":
-  version "9.9.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.9.0.tgz#47cbf1cab003e52b3fe2acfecc703090fcd00bda"
-  integrity sha512-Vwqe6Q5cU4i82tPyAv2BpaW/fQSNdOSO4/J8EeDLPp5/oIZiMmdB+Hgh863zFH+rtoxpuWGvD1L7QPh8k1Rdvw==
+"@stripe/stripe-js@^9.12.0":
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-9.12.0.tgz#f524394cf791d4936d6ca5277518ad9f69cf8b72"
+  integrity sha512-wCUYZNYo7E/6B3Rv2i/g/Rmj2mTiOX6HEwWYUWUuNUKwEhzTo/SXuQ1IoNo3mknWIHUQyqdakv1Nl2SiYPrCrw==
 
 "@swc/helpers@0.5.15":
   version "0.5.15"
@@ -2328,10 +2328,10 @@ https-proxy-agent@^5.0.1:
     agent-base "6"
     debug "4"
 
-i18next@^26.3.4:
-  version "26.3.4"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-26.3.4.tgz#a2e8540b0a1a6004eba525c05faa89c256fb57c8"
-  integrity sha512-pa7m0d7pBDqGHZxljT+WPFeyFgQ7P7SciPPo1tTqYuO0z4sqADYhwnBESmmGp/wEof1inwdls/k8ZgTg8rxFHA==
+i18next@^26.3.6:
+  version "26.3.6"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-26.3.6.tgz#599db275c50b66d28a69d8f6c5162c245ce9296b"
+  integrity sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==
 
 ieee754@^1.2.1:
   version "1.2.1"
@@ -3526,10 +3526,10 @@ styled-components@^6.3.12:
     csstype "3.2.3"
     stylis "4.3.6"
 
-styled-components@^6.4.3:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.4.3.tgz#9544423c537b76ba091cb5a8b6b4f36833df4cfc"
-  integrity sha512-wYXrhu+JmDjZ1Tv7O0OopGTfztbzun43Pjjhh2H+xc0h5A09dwpZ5FJbrifJDcL8g5TA9btpWOX2+iSRuJTExw==
+styled-components@^6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.4.4.tgz#403eb7046b9f59a170d13967d9e7d21d82e677bd"
+  integrity sha512-tJk5CmKUPMDoTsZQ8m0hHInBk9HFKUPSusqmbBuefDX+yUbMBWea2Ob/wdXFyHW8XZqXkprJscysAdKeGWNqlA==
   dependencies:
     "@emotion/is-prop-valid" "1.4.0"
     css-to-react-native "3.2.0"


### PR DESCRIPTION
This PR updates the @schematichq/schematic-components package to version 2.21.0.

This update was automatically created by the schematic-components deployment process.