### PR TITLE
Update @schematichq/schematic-components to 2.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.1",
-    "@schematichq/schematic-components": "2.22.0",
+    "@schematichq/schematic-components": "2.22.1",
     "@schematichq/schematic-react": "1.5.0",
     "@schematichq/schematic-typescript-node": "^1.4.4",
     "@stripe/react-stripe-js": "^5.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,10 +630,10 @@
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@schematichq/schematic-components@2.22.0":
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.22.0.tgz#c676674ce3fa05577ee0b36bd40189477a6eb5a1"
-  integrity sha512-rU604vBTFpeSnTPAFF38NJ0Au+Z0fxuI0kRNShZTlfqQx8yEf/jW881d9hB7bE+vT8QQW2EEZa5EaHTB1tBmCQ==
+"@schematichq/schematic-components@2.22.1":
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/@schematichq/schematic-components/-/schematic-components-2.22.1.tgz#3569d98bbc92ebb578ab98251b914f4ee1004737"
+  integrity sha512-Fne8SBU2MGdGzzdF4WunxEjK8LVmf1tELymPUG+fxn7ENSlJuvIpqnFuxXO2sD35K+zf8g06Et2FkTadj7//zg==
   dependencies:
     "@schematichq/schematic-icons" "^0.8.0"
     "@stripe/stripe-js" "^9.12.1"


### PR DESCRIPTION
This PR updates the @schematichq/schematic-components package to version 2.22.1.

This update was automatically created by the schematic-components deployment process.