### PR TITLE
chore(deps): pin node 24 for vercel builds

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,6 +3,10 @@ frontend:
   phases:
     preBuild:
       commands:
+        # Amplify takes node from the build image, not package.json. Without this
+        # the image's node loses to the engines.node pin and yarn refuses to install.
+        - nvm install 24
+        - nvm use 24
         - yarn install
     build:
       commands:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "schematic-next-example",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "next dev --webpack",
     "build": "next build --webpack",


### PR DESCRIPTION
Vercel deprecates Node 20 — builds fail after 2026-10-01. This repo pinned Node nowhere (no `engines`, no `.nvmrc`, no `.node-version`), so the version came only from the Vercel project setting. Vercel honors `engines.node` as an override and 24.x is already its default.

The second commit is the consequence of the first: Amplify takes Node from its build image rather than from `package.json`, so if that image is older than 24 the new `engines` pin makes yarn classic refuse to install. `nvm install 24 && nvm use 24` in `preBuild` keeps the two surfaces on the same version.

Nothing else is needed here: there is no CI workflow, and `@types/node` is already `^25.6.0`.

Requested in https://schematichq.slack.com/archives/C05L377BBS4/p1786734827876899?thread_ts=1786734744.114419&cid=C05L377BBS4 — companion PR SchematicHQ/schematic-ms#339.

Verified on node v24.18.0: `yarn install`, `yarn lint`, `npx tsc --noEmit` and `yarn build` all pass. (The build needs the Schematic keys from `.env.example` — with them empty it fails prerendering on "No Schematic Publishable Key found"; with placeholders it completes all 11 routes.) The amplify.yml change is the one thing I could not exercise: there is no Amplify build in the sandbox, so `nvm install 24` is unverified against the real image.