### PR TITLE
add fixture-driven demo pages for the v3 elements

### DIFF
--- a/src/app/v3/V3Demo.tsx
+++ b/src/app/v3/V3Demo.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  CatalogDataProvider,
+  CreditUsage,
+  IncludedFeatures,
+  Invoices,
+  MeteredFeatures,
+  PlanManager,
+  PricingTable,
+  SchematicStyles,
+  UpcomingBill,
+} from "@schematichq/schematic-components/v3";
+import { NOW, SCENARIOS } from "@schematichq/schematic-components/v3/fixtures";
+import { useMemo } from "react";
+
+import { ELEMENTS, type ElementSlug } from "./elements";
+
+const SCENARIO_NAMES = Object.keys(SCENARIOS) as (keyof typeof SCENARIOS)[];
+
+function log(name: string) {
+  return (...args: unknown[]) => console.log(`[v3] ${name}`, ...args);
+}
+
+/**
+ * Renders one v3 element from a fixture scenario — no API, no auth — so the
+ * elements can be checked visually in every state the fixtures describe.
+ */
+export default function V3Demo({ element }: { element: ElementSlug }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const scenarioParam = params.get("scenario");
+  const scenario: keyof typeof SCENARIOS =
+    scenarioParam !== null && scenarioParam in SCENARIOS
+      ? (scenarioParam as keyof typeof SCENARIOS)
+      : element === "pricing-table"
+        ? "public"
+        : "pro";
+  const data = useMemo(() => SCENARIOS[scenario](), [scenario]);
+
+  let content: React.ReactNode;
+  switch (element) {
+    case "pricing-table":
+      content = (
+        <PricingTable
+          showZeroPriceAsFree
+          callToActionUrl="/usage"
+          onSelectPlan={log("onSelectPlan")}
+          onSelectAddOn={log("onSelectAddOn")}
+        />
+      );
+      break;
+    case "plan-manager":
+      content = (
+        <PlanManager
+          now={NOW}
+          onChangePlan={log("onChangePlan")}
+          onEditAutoTopup={log("onEditAutoTopup")}
+        />
+      );
+      break;
+    case "included-features":
+      content = <IncludedFeatures />;
+      break;
+    case "metered-features":
+      content = <MeteredFeatures onAddMore={log("onAddMore")} />;
+      break;
+    case "credit-usage":
+      content = <CreditUsage onBuyBundle={log("onBuyBundle")} />;
+      break;
+    case "invoices":
+      content = <Invoices />;
+      break;
+    case "upcoming-bill":
+      content = <UpcomingBill />;
+      break;
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <SchematicStyles />
+      <nav className="flex flex-wrap items-center gap-3 text-sm">
+        {(Object.keys(ELEMENTS) as ElementSlug[]).map((slug) => (
+          <Link
+            key={slug}
+            href={`/v3/${slug}?scenario=${scenario}`}
+            className={slug === element ? "font-semibold underline" : ""}
+          >
+            {ELEMENTS[slug]}
+          </Link>
+        ))}
+        <label className="ml-auto flex items-center gap-2">
+          Scenario
+          <select
+            className="rounded border px-2 py-1"
+            value={scenario}
+            onChange={(event) =>
+              router.replace(`/v3/${element}?scenario=${event.target.value}`)
+            }
+          >
+            {SCENARIO_NAMES.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </nav>
+      <CatalogDataProvider
+        data={data}
+        onRefetch={log("refetch")}
+        onLoadMoreInvoices={log("loadMoreInvoices")}
+      >
+        {content}
+      </CatalogDataProvider>
+    </div>
+  );
+}

--- a/src/app/v3/[element]/page.tsx
+++ b/src/app/v3/[element]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+
+import V3Demo from "../V3Demo";
+import { ELEMENTS, type ElementSlug } from "../elements";
+
+export function generateStaticParams() {
+  return Object.keys(ELEMENTS).map((element) => ({ element }));
+}
+
+export default async function V3ElementPage({
+  params,
+}: {
+  params: Promise<{ element: string }>;
+}) {
+  const { element } = await params;
+  if (!(element in ELEMENTS)) {
+    notFound();
+  }
+  return (
+    <Suspense>
+      <V3Demo element={element as ElementSlug} />
+    </Suspense>
+  );
+}

--- a/src/app/v3/elements.ts
+++ b/src/app/v3/elements.ts
@@ -1,0 +1,13 @@
+/** The v3 elements the demo can render, by URL slug. Plain module: the
+ * server page reads it, so it must not carry a "use client" directive. */
+export const ELEMENTS = {
+  "pricing-table": "PricingTable",
+  "plan-manager": "PlanManager",
+  "included-features": "IncludedFeatures",
+  "metered-features": "MeteredFeatures",
+  "credit-usage": "CreditUsage",
+  invoices: "Invoices",
+  "upcoming-bill": "UpcomingBill",
+} as const;
+
+export type ElementSlug = keyof typeof ELEMENTS;

--- a/src/app/v3/page.tsx
+++ b/src/app/v3/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+import { ELEMENTS } from "./elements";
+
+export default function V3Index() {
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl font-semibold">v3 elements</h1>
+      <p className="text-sm text-gray-600">
+        Each element rendered from fixture scenarios (no API). Pick an element,
+        then switch scenarios on its page.
+      </p>
+      <ul className="list-disc pl-6">
+        {Object.entries(ELEMENTS).map(([slug, name]) => (
+          <li key={slug}>
+            <Link className="underline" href={`/v3/${slug}`}>
+              {name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds `/v3/[element]?scenario=…` pages that render each of the seven v3 elements from the fixture scenarios shipped in `@schematichq/schematic-components/v3/fixtures`, with no API or auth involved, so every state the fixtures describe can be checked visually.

Depends on the linked `v3-elements` branch of schematic-js (SchematicHQ/schematic-js); the published packages do not carry the `/v3` subpaths yet.